### PR TITLE
Set POST authorization header beforehand to avoid a first 401 response 

### DIFF
--- a/source/js/background.js
+++ b/source/js/background.js
@@ -74,8 +74,12 @@ function rpcTransmission(args, method, tag, callback) {
 		{
 			url: localStorage.server + localStorage.rpcPath,
 			type: 'POST',
-			username: localStorage.user,
-			password: localStorage.pass,
+			beforeSend: function (xhr) {
+					if ( localStorage.user != '')
+					{
+						xhr.setRequestHeader('Authorization ', 'Basic ' + btoa(localStorage.user +':' + localStorage.pass));
+					}
+		   		},
 			headers: {'X-Transmission-Session-Id': localStorage.sessionId},
 			data: '{ "arguments": {' + args + '}, "method": "' + method + '"' + (tag ? ', "tag": ' + tag : '') + '}'
 		}


### PR DESCRIPTION
This solves an issue I encountered using extension on my computer on same LAN as the server: nothing was working and parse exception was seen in log. 

With previous method, I could see a first request without credential issued to the server, which replied with 401 error code, then only was the request which gave a 409 answer with X-Transmission-Session-Id.

With debuger, in complete function I could see header of the 401 answer  (without X-Transmission-Session-Id) and body of the 409 answer. excption was from JSON.Parse of "<h1>409..."

I don't really get why I had, this strange behavior of mixed answers, and this is not seen on WAN access,
but proposed fix avoid a first POST without credential and solves the issue.
