### PR TITLE
Fix dropdown menu hidden when no torrents and multiple torrents

### DIFF
--- a/source/css/popup.css
+++ b/source/css/popup.css
@@ -160,6 +160,7 @@ input[type="text"] {
 #list_wrapper {
 	overflow: auto;
 	max-height: 527px;
+	min-height: 45px;
 }
 
 #list {

--- a/source/js/popup.js
+++ b/source/js/popup.js
@@ -108,6 +108,11 @@ function setStatusVisibility() {
 port.onMessage.addListener(function(msg) {
 	switch(msg.tag) {
 		case TAG_BASELINE:
+			// remove all previous torrents
+			for (var i = 0; torrent = torrents[i]; ++i) {
+				torrents.splice(torrent, 1)[0].removeElem();
+			}
+
 			var uTorrents = msg.args.torrents.sort(function(a, b) { return b.addedDate - a.addedDate; });
 
 			// add the torrent to the torrents array and set whether it's visible or not


### PR DESCRIPTION
It correspond to the issue #9 and #6.
There is a simple fix for the dropdown menu.
There is also a fix for error messages, when we receive a message with a tag `TAG_BASELINE`, we didn't clear all previous torrents (previous error messages).
I would also fix the issue #6 but I think it is the same because I don't have the bug anymore.