### PR TITLE
Fix reading of start_paused localStorage

### DIFF
--- a/source/js/background.js
+++ b/source/js/background.js
@@ -113,7 +113,7 @@ function getTorrent(url) {
 	var dirs = (localStorage.dirs) ? JSON.parse(localStorage.dirs) : [];
 	// show download popup?
 	if (localStorage.dlPopup === 'false') {
-		dlTorrent({ 'url': url, 'paused': localStorage.start_paused });
+		dlTorrent({ 'url': url, 'paused': (localStorage.start_paused === 'true') });
 	} else {
 		// don't use base64 on magnet links
 		if (url.toLowerCase().indexOf('magnet:') == 0) {	//it's a magnet


### PR DESCRIPTION
Booleans are stored in localStorage as strings. And since `Boolean("false") == true`, this would cause `localStorage.start_paused` to be misinterpreted.

If we implement #22 this would no longer be an issue, as chrome.strorage can store booleans (and other objects). Another option would be to wrap localStorage with `JSON.stringify()` on store and `JSON.parse()` on load. I'm not sure what the other (dis)advantages of chrome.storage are.

That would allow us to remove all these ugly and error-prone `=== 'true'` comparisons.