### PR TITLE
Fix notification on completed torrent

### DIFF
--- a/source/background.html
+++ b/source/background.html
@@ -4,6 +4,7 @@
 <script type="text/javascript" src="js/bencode.js"></script>
 <script type="text/javascript" src="js/torrentParsing.js"></script>
 <script type="text/javascript" src="js/jquery-3.2.1.min.js"></script>
+<script type="text/javascript" src="js/class.js"></script>
 <script type="text/javascript" src="js/background.js"></script>
 </head>
 <body>

--- a/source/js/background.js
+++ b/source/js/background.js
@@ -210,7 +210,7 @@ function notificationRefresh() {
   rpcTransmission('"fields": [ "id", "name", "status", "leftUntilDone" ], "ids": "recently-active"', 'torrent-get', 10, function (response) {
     for (let i = 0; i < response.arguments.torrents.length; i++) {
       let torrent = response.arguments.torrents[i];
-      if (torrent.status === 16 && torrent.leftUntilDone === 0 && completedTorrents.indexOf(torrent.id) < 0) {
+      if (torrent.status === TR_STATUS_SEED && torrent.leftUntilDone === 0 && completedTorrents.indexOf(torrent.id) < 0) {
         showNotification('Torrent Download Complete', torrent.name + ' has finished downloading.');
         // mark the completed torrent so another notification isn't displayed for it
         completedTorrents += torrent.id + ',';

--- a/source/js/background.js
+++ b/source/js/background.js
@@ -253,11 +253,19 @@ chrome.extension.onConnect.addListener(function (port) {
       break;
     case 'options':
       port.onMessage.addListener(function (msg) {
-        // stop the notification timer
-        clearTimeout(notificationTimer);
+        switch (msg.method) {
+          case 'settings-saved':
+            // stop the notification timer
+            clearTimeout(notificationTimer);
 
-        // start it up again if it's enabled
-        if (msg.notifications) {notificationRefresh();}
+            // start it up again if it's enabled
+            if (localStorage.notificationstorrentfinished === 'true') {
+              notificationRefresh();
+            }
+            break;
+          default:
+            break;
+        }
       });
       break;
     case 'downloadMagnet':

--- a/source/js/background.js
+++ b/source/js/background.js
@@ -210,7 +210,8 @@ function notificationRefresh() {
   rpcTransmission('"fields": [ "id", "name", "status", "leftUntilDone" ], "ids": "recently-active"', 'torrent-get', 10, function (response) {
     for (let i = 0; i < response.arguments.torrents.length; i++) {
       let torrent = response.arguments.torrents[i];
-      if (torrent.status === TR_STATUS_SEED && torrent.leftUntilDone === 0 && completedTorrents.indexOf(torrent.id) < 0) {
+      if ((torrent.status === TR_STATUS_SEED_WAIT || torrent.status === TR_STATUS_SEED || torrent.status === TR_STATUS_STOPPED) &&
+          torrent.leftUntilDone === 0 && completedTorrents.indexOf(torrent.id) < 0) {
         showNotification('Torrent Download Complete', torrent.name + ' has finished downloading.');
         // mark the completed torrent so another notification isn't displayed for it
         completedTorrents += torrent.id + ',';

--- a/source/js/class.js
+++ b/source/js/class.js
@@ -2,16 +2,16 @@
 
 /* global formatBytes */
 
+const TR_STATUS_STOPPED        = 0; /* Torrent is stopped */
+const TR_STATUS_CHECK_WAIT     = 1; /* Queued to check files */
+const TR_STATUS_CHECK          = 2; /* Checking files */
+const TR_STATUS_DOWNLOAD_WAIT  = 3; /* Queued to download */
+const TR_STATUS_DOWNLOAD       = 4; /* Downloading */
+const TR_STATUS_SEED_WAIT      = 5; /* Queued to seed */
+const TR_STATUS_SEED           = 6; /* Seeding */
+
 /* exported Torrent */
 function Torrent() {
-
-  const TR_STATUS_STOPPED        = 0; /* Torrent is stopped */
-  const TR_STATUS_CHECK_WAIT     = 1; /* Queued to check files */
-  const TR_STATUS_CHECK          = 2; /* Checking files */
-  const TR_STATUS_DOWNLOAD_WAIT  = 3; /* Queued to download */
-  const TR_STATUS_DOWNLOAD       = 4; /* Downloading */
-  const TR_STATUS_SEED_WAIT      = 5; /* Queued to seed */
-  const TR_STATUS_SEED           = 6; /* Seeding */
 
   var oPauseBtn;
   var oResumeBtn;

--- a/source/js/options.js
+++ b/source/js/options.js
@@ -95,10 +95,6 @@ function save() {
   localStorage.browserbadgetimeout = jQuery('#browserbadgetimeout').val();
   localStorage.popuprefreshinterval = jQuery('#popuprefreshinterval').val();
 
-  // send message to background page to en/disable notifications
-  port.postMessage({notificationstorrentfinished: jQuery('#notificationstorrentfinished').prop('checked')});
-  port.postMessage({notificationsnewtorrent: jQuery('#notificationsnewtorrent').prop('checked')});
-
   localStorage.start_paused = jQuery('#start_paused').prop('checked');
 
   // whether to handle the torrent click (i.e. download remotely) or leave to chrome to handle (download locally)
@@ -116,6 +112,9 @@ function save() {
   localStorage.dirs = JSON.stringify(dirs);
 
   localStorage.version = chrome.runtime.getManifest().version;
+
+  // send message to background that options were saved
+  port.postMessage({method: 'settings-saved'});
 
   jQuery('#saved').fadeIn(100);
   jQuery('#saved').fadeOut(1000);


### PR DESCRIPTION
The status of a completed torrent (`TR_STATUS_SEED`) is `6`, not `16`.

The correct values are already in `js/class.js`, so I included that file instead of duplicating all the constants in `js/background.js`. (Maybe those should be split to a separate file as the rest of `js/class.js` is not used in `js/background.js`.)

Fixes #26