### PR TITLE
Use chrome.runtime instead of deprecated chrome.extension functions

### DIFF
--- a/source/js/background.js
+++ b/source/js/background.js
@@ -225,7 +225,7 @@ function notificationRefresh() {
 /*
  * receive messages from other parts of the script
  */
-chrome.extension.onConnect.addListener(function (port) {
+chrome.runtime.onConnect.addListener(function (port) {
   switch (port.name) {
     case 'popup':
       port.onMessage.addListener(function (msg) {
@@ -291,7 +291,7 @@ chrome.extension.onConnect.addListener(function (port) {
 /**
  * recieve message to send torrent to transmission
  */
-chrome.extension.onMessage.addListener(function (request, sender, sendResponse) {
+chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request.method === 'get-torrent-info') {
     sendResponse(torrentInfo[request.page]);
   } else {

--- a/source/js/downloadMagnet.js
+++ b/source/js/downloadMagnet.js
@@ -2,7 +2,7 @@
 
 var selectNewDirectoryIndex = 1;
 const TAG_DOWNLOAD_DIR = 1;
-var port = chrome.extension.connect({name: 'downloadMagnet'});
+var port = chrome.runtime.connect({name: 'downloadMagnet'});
 
 function decodeString(s) {
   var r;
@@ -15,7 +15,7 @@ function decodeString(s) {
 }
 
 // populate the download popup with the torrent information
-chrome.extension.sendMessage({method: 'get-torrent-info', page: 'magnet'}, function (request) {
+chrome.runtime.sendMessage({method: 'get-torrent-info', page: 'magnet'}, function (request) {
   var select = jQuery('#downloadLocations');
   var newLabel = jQuery('#newLabel');
   var newDirectory = jQuery('#newDirectory');
@@ -49,7 +49,7 @@ chrome.extension.sendMessage({method: 'get-torrent-info', page: 'magnet'}, funct
     } else {
       message.dir = select.val();
     }
-    chrome.extension.sendMessage(message);
+    chrome.runtime.sendMessage(message);
     window.close();
   });
 

--- a/source/js/downloadTorrent.js
+++ b/source/js/downloadTorrent.js
@@ -1,6 +1,6 @@
 var selectNewDirectoryIndex = 1;
 const TAG_DOWNLOAD_DIR = 1;
-var port = chrome.extension.connect({name: 'downloadTorrent'});
+var port = chrome.runtime.connect({name: 'downloadTorrent'});
 
 // credit to: http://web.elctech.com/2009/01/06/convert-filesize-bytes-to-readable-string-in-javascript/
 // modified to allow for 0 bytes and removed extraneous Math.floor
@@ -106,7 +106,7 @@ function sortFiles(a, b) {
 }
 
 // populate the download popup with the torrent information
-chrome.extension.sendMessage({method: 'get-torrent-info', page: 'torrent'}, function (request) {
+chrome.runtime.sendMessage({method: 'get-torrent-info', page: 'torrent'}, function (request) {
   var select = jQuery('#downloadLocations');
   var newLabel = jQuery('#newLabel');
   var newDirectory = jQuery('#newDirectory');
@@ -237,7 +237,7 @@ chrome.extension.sendMessage({method: 'get-torrent-info', page: 'torrent'}, func
     } else {
       message.dir = select.val();
     }
-    chrome.extension.sendMessage(message);
+    chrome.runtime.sendMessage(message);
     window.close();
   });
 

--- a/source/js/inject.js
+++ b/source/js/inject.js
@@ -24,7 +24,7 @@ var TORRENT_LINKS = [
 ];
 
 // open up a session with the background page
-var port = chrome.extension.connect({name: 'inject'});
+var port = chrome.runtime.connect({name: 'inject'});
 
 /* =================================================================================
  clickTorrent(event e)

--- a/source/js/options.js
+++ b/source/js/options.js
@@ -1,5 +1,5 @@
 // communication port with background page
-var port = chrome.extension.connect({name: 'options'});
+var port = chrome.runtime.connect({name: 'options'});
 
 // add custom download directory to table
 /* =================================================================================

--- a/source/js/popup.js
+++ b/source/js/popup.js
@@ -1,7 +1,7 @@
 // global variables
 var torrents = [];  // array of displayed torrents
 var refresh;    // variable that holds refreshPopup() timeout
-var port = chrome.extension.connect({name: 'popup'});
+var port = chrome.runtime.connect({name: 'popup'});
 
 const TAG_BASELINE    = 1;
 const TAG_UPDATE    = 2;


### PR DESCRIPTION
These chrome.extension functions aren't mentioned anywhere in the [Chrome](https://developer.chrome.com/docs/extensions/reference/) or [MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/extension) docs. They have been deprecated around Chrome 28. [MDN says](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/extension): "Note that the messaging APIs in this module are deprecated in favor of the equivalent APIs in the runtime module."

They are functionally the same but this makes it easier to find the [right docs](https://developer.chrome.com/docs/extensions/reference/runtime/).