### PR TITLE
Check the jqXHR status code for 409 error

### DIFF
--- a/source/js/background.js
+++ b/source/js/background.js
@@ -62,7 +62,7 @@ function rpcTransmission(args, method, tag, callback) {
     }
   })
   .fail(function (jqXHR, textStatus, errorThrown) {
-    if (errorThrown === 'Conflict') {
+    if (errorThrown === 'Conflict' || jqXHR.status === 409) {
       // X-Transmission-Session-Id should only be included if we didn't include it when we sent our request
       let xSid = jqXHR.getResponseHeader('X-Transmission-Session-Id');
       localStorage.sessionId = xSid;


### PR DESCRIPTION
Sometimes errorThrown is not set properly and the header doesn't get set. This additional condition fixes that by also checking for the HTTP 409 status code and setting the X-Transmission-Session-Id.