### PR TITLE
Fix errors where errorThrown is not populated in chrome

### DIFF
--- a/source/js/background.js
+++ b/source/js/background.js
@@ -62,7 +62,7 @@ function rpcTransmission(args, method, tag, callback) {
     }
   })
   .fail(function (jqXHR, textStatus, errorThrown) {
-    if (errorThrown === 'Conflict') {
+    if (jqXHR == 409) {
       // X-Transmission-Session-Id should only be included if we didn't include it when we sent our request
       let xSid = jqXHR.getResponseHeader('X-Transmission-Session-Id');
       localStorage.sessionId = xSid;


### PR DESCRIPTION
Issue:
https://github.com/YodaDaCoda/chrome-transmission-remote-plus/issues/52#issue-834505118

Debug info in issue. Tested with local client