### PR TITLE
Fix: Popup not opening in some screen sizes

### DIFF
--- a/source/js/background.js
+++ b/source/js/background.js
@@ -177,8 +177,8 @@ function getTorrent(url) {
       type   : 'popup',
       width  : 852,
       height : 190,
-      left   : screen.width / 2 - 852 / 2,
-      top    : screen.height / 2 - 160 / 2,
+      left   : Math.round(screen.width / 2) - 852 / 2,
+      top    : Math.round(screen.height / 2) - 160 / 2,
     });
   } else { // it's a .torrent
     getFile(url, function (file) {
@@ -191,8 +191,8 @@ function getTorrent(url) {
               type   : 'popup',
               width  : 850,
               height : 610,
-              left   : (screen.width / 2) - 425,
-              top    : (screen.height / 2) - 300,
+              left   : Math.round(screen.width / 2) - 425,
+              top    : Math.round(screen.height / 2) - 300,
             });
           });
         } else {


### PR DESCRIPTION
Adding a round() method to fix issues where Chrome errors on `chrome.window.create` because `screen.{width,height}/2` is not a whole integer.

![image](https://user-images.githubusercontent.com/6681183/163708390-e21c9e33-fdff-4844-a5f4-a52a970cba29.png)

```
Uncaught TypeError: Error in invocation of windows.create(optional object createData, optional function callback): Error at parameter 'createData': Error at property 'left': Invalid type: expected integer, found number.
    at background.js:189:28
    at FileReader.reader.onload (torrentParsing.js:48:5)
```

My Framework laptop reports a screen width of `1805`, which causes an issue here. I suspect other screens such as high-density displays will also report sizes that don't divide nicely.